### PR TITLE
Add feature to join missions

### DIFF
--- a/src/components/MissionItem.js
+++ b/src/components/MissionItem.js
@@ -1,14 +1,23 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { useDispatch } from 'react-redux';
+import Badge from 'react-bootstrap/Badge';
+import Button from 'react-bootstrap/Button';
+import { joinMission } from '../redux/missions/missions';
 
 const MissionItem = (props) => {
   const { mission } = props;
-  // const badgeClass = mission.isReserved ? 'reserveBadge' : 'reserveBadgeDisabled';
+  const dispatch = useDispatch();
+  const clickHandler = () => {
+    dispatch(joinMission(mission.mission_id));
+  };
 
   return (
     <tr>
       <th><h3>{mission.mission_name}</h3></th>
       <th><p>{mission.mission_description}</p></th>
+      <th className="align-middle"><Badge bg="primary">Active Member</Badge></th>
+      <th className="align-middle"><Button onClick={clickHandler} type="button" variant="outline-secondary">Join Mission</Button></th>
     </tr>
   );
 };

--- a/src/components/MissionItem.js
+++ b/src/components/MissionItem.js
@@ -10,6 +10,7 @@ const MissionItem = (props) => {
   const dispatch = useDispatch();
   const clickHandler = () => {
     dispatch(joinMission(mission.mission_id));
+    console.log(mission);
   };
 
   return (
@@ -27,6 +28,7 @@ MissionItem.propTypes = {
     mission_id: PropTypes.string.isRequired,
     mission_name: PropTypes.string.isRequired,
     mission_description: PropTypes.string,
+    isJoined: PropTypes.bool,
   }).isRequired,
 };
 

--- a/src/components/MissionsList.js
+++ b/src/components/MissionsList.js
@@ -19,8 +19,8 @@ const MissionsList = () => {
         <tr>
           <th>Mission</th>
           <th>Description</th>
-          {/* <th>Status</th>
-          <th>Action</th> */}
+          <th>Status</th>
+          <th>Action</th>
         </tr>
       </thead>
       <tbody>

--- a/src/redux/missions/missions.js
+++ b/src/redux/missions/missions.js
@@ -47,9 +47,8 @@ const missionsReducer = (state = initialState, action) => {
   switch (action.type) {
     case GET_MISSIONS:
       return action.payload;
-    case JOIN_MISSION: {
+    case JOIN_MISSION:
       return missionStatus(state, action.id, true);
-    }
     default:
       return state;
   }

--- a/src/redux/missions/missions.js
+++ b/src/redux/missions/missions.js
@@ -48,7 +48,6 @@ const missionsReducer = (state = initialState, action) => {
     case GET_MISSIONS:
       return action.payload;
     case JOIN_MISSION: {
-      console.log(state);
       return missionStatus(state, action.id, true);
     }
     default:

--- a/src/redux/missions/missions.js
+++ b/src/redux/missions/missions.js
@@ -1,6 +1,7 @@
 import { fetchMissions } from '../APIcall';
 
 const GET_MISSIONS = 'Space_Travelers/missions/GET_MISSIONS';
+const JOIN_MISSION = 'Space_Travelers/missions/JOIN_MISSION';
 
 const initialState = [];
 
@@ -21,11 +22,22 @@ export const getMissions = () => async (dispatch) => {
   isLoading = true;
 };
 
+export const joinMission = (id) => (
+  {
+    type: JOIN_MISSION,
+    id,
+  });
+
 const missionsReducer = (state = initialState, action) => {
   switch (action.type) {
     case GET_MISSIONS:
       return action.payload;
-
+    case JOIN_MISSION: {
+      console.log(state);
+      return state.map((mission) => (mission.mission_id === action.id
+        ? { ...mission, reserved: true }
+        : mission));
+    }
     default:
       return state;
   }

--- a/src/redux/missions/missions.js
+++ b/src/redux/missions/missions.js
@@ -14,6 +14,7 @@ export const getMissions = () => async (dispatch) => {
     mission_id: mission.mission_id,
     mission_name: mission.mission_name,
     mission_description: mission.description,
+    isJoined: false,
   }));
   dispatch({
     type: GET_MISSIONS,
@@ -22,11 +23,25 @@ export const getMissions = () => async (dispatch) => {
   isLoading = true;
 };
 
-export const joinMission = (id) => (
-  {
-    type: JOIN_MISSION,
-    id,
+export const joinMission = (id) => ({
+  type: JOIN_MISSION,
+  id,
+});
+
+const missionStatus = (state, id, status) => {
+  const newState = state.map((mission) => {
+    if (mission.mission_id !== id) {
+      return mission;
+    }
+    return {
+      mission_id: mission.mission_id,
+      mission_name: mission.mission_name,
+      mission_description: mission.mission_description,
+      isJoined: status,
+    };
   });
+  return newState;
+};
 
 const missionsReducer = (state = initialState, action) => {
   switch (action.type) {
@@ -34,9 +49,7 @@ const missionsReducer = (state = initialState, action) => {
       return action.payload;
     case JOIN_MISSION: {
       console.log(state);
-      return state.map((mission) => (mission.mission_id === action.id
-        ? { ...mission, reserved: true }
-        : mission));
+      return missionStatus(state, action.id, true);
     }
     default:
       return state;


### PR DESCRIPTION
## #10 Implement Mission Joining Action 
- [x] When a user clicks the "Join Mission" button, action needs to be dispatched to update the store. You need to get the ID of the selected mission and update the state. Remember you mustn't mutate the state. Instead, you need to return a new state object with all missions, but the selected mission will have an extra key reserved with its value set to true. You could use a JS filter() or map() to set the value of the new state - i.e.:
- [x] Regardless of which method you choose, make sure you place all your logic in the reducer. In the React view file, you should only dispatch the action with the correct rocket ID as an argument.